### PR TITLE
Pin GHA versions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,9 +12,9 @@ jobs:
     container:
       image: michaelfbryan/mdbook-docker-image
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
     - run: mdbook build
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: book
         path: ./book
@@ -24,11 +24,11 @@ jobs:
     needs: build-book
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: book
           path: ./book
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.
Additionally added `dependabot` to track GHA version changes.
Related issues and policy:
https://github.com/paritytech/ci_cd/issues/114
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies