### PR TITLE
Clarify the childTrie parameter of chainHead_unstable_storage

### DIFF
--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -5,12 +5,12 @@
 - `followSubscription`: An opaque string that was returned by `chainHead_unstable_follow`.
 - `hash`: String containing an hexadecimal-encoded hash of the header of the block whose storage to fetch.
 - `key`: String containing the hexadecimal-encoded key to fetch in the storage.
-- `childKey`: `null` for main storage look-ups, or a string containing the hexadecimal-encoded key of the trie key of the trie that `key` refers to. **TODO**: I don't know enough about child tries to design this properly
+- `childTrie`: `null` for main storage look-ups, or a string containing the hexadecimal-encoded key of the child trie of the "default" namespace.
 - `networkConfig` (optional): Object containing the configuration of the networking part of the function. See [here](./api.md) for details. Ignored if the JSON-RPC server doesn't need to perform a network request. Sensible defaults are used if not provided.
 
 **Return value**: String containing an opaque value representing the operation.
 
-The JSON-RPC server must start obtaining the value of the entry with the given `key` (and possibly `childKey`) from the storage.
+The JSON-RPC server must start obtaining the value of the entry with the given `key` from the storage, either from the main trie of from `childTrie`.
 
 The operation will continue even if the given block is unpinned while it is in progress.
 

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -10,7 +10,7 @@
 
 **Return value**: String containing an opaque value representing the operation.
 
-The JSON-RPC server must start obtaining the value of the entry with the given `key` from the storage, either from the main trie of from `childTrie`.
+The JSON-RPC server must start obtaining the value of the entry with the given `key` from the storage, either from the main trie or from `childTrie`.
 
 The operation will continue even if the given block is unpinned while it is in progress.
 


### PR DESCRIPTION
Now that I understand child tries, this PR clarifies the meaning of this parameter.

Note that only default child tries are possible. If we ever get non-default child tries (which right now seems unlikely) then the course of action would be to create a `chainHead_v2_storage` function (assuming the current one would be stabilized under `chainHead_v1_storage`).
