### PR TITLE
Stabilize `transaction`-prefixed functions

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -41,5 +41,5 @@
   - [sudo_sessionKeys]()
     - [sudo_sessionKeys_unstable_generate](api/sudo_sessionKeys_unstable_generate.md)
   - [transaction](api/transaction.md)
-    - [transaction_unstable_submitAndWatch](api/transaction_unstable_submitAndWatch.md)
-    - [transaction_unstable_unwatch](api/transaction_unstable_unwatch.md)
+    - [transaction_v1_submitAndWatch](api/transaction_v1_submitAndWatch.md)
+    - [transaction_v1_unwatch](api/transaction_v1_unwatch.md)

--- a/src/api/transaction_v1_submitAndWatch.md
+++ b/src/api/transaction_v1_submitAndWatch.md
@@ -1,4 +1,4 @@
-# transaction_unstable_submitAndWatch
+# transaction_v1_submitAndWatch
 
 **Parameters**:
 
@@ -6,9 +6,9 @@
 
 **Return value**: String representing the subscription.
 
-The string returned by this function is opaque and its meaning can't be interpreted by the JSON-RPC client. It is only meant to be matched with the `subscription` field of events and potentially passed to `transaction_unstable_unwatch`.
+The string returned by this function is opaque and its meaning can't be interpreted by the JSON-RPC client. It is only meant to be matched with the `subscription` field of events and potentially passed to `transaction_v1_unwatch`.
 
-Once this function has been called, the server will try to propagate this transaction over the peer-to-peer network and/or include it onto the chain even if `transaction_unstable_unwatch` is called or that the JSON-RPC client disconnects. In other words, it is not possible to cancel submitting a transaction.
+Once this function has been called, the server will try to propagate this transaction over the peer-to-peer network and/or include it onto the chain even if `transaction_v1_unwatch` is called or that the JSON-RPC client disconnects. In other words, it is not possible to cancel submitting a transaction.
 
 ## Notifications format
 

--- a/src/api/transaction_v1_unwatch.md
+++ b/src/api/transaction_v1_unwatch.md
@@ -1,8 +1,8 @@
-# transaction_unstable_unwatch
+# transaction_v1_unwatch
 
 **Parameters**:
 
-- `subscription`: Opaque string equal to the value returned by `transaction_unstable_submitAndWatch`
+- `subscription`: Opaque string equal to the value returned by `transaction_v1_submitAndWatch`
 
 **Return value**: *null*
 

--- a/src/dos-attacks-resilience.md
+++ b/src/dos-attacks-resilience.md
@@ -34,7 +34,7 @@ The events coming from the blockchain node can be seen as a stream. This stream 
 
 However, sending a message to a JSON-RPC client might take a long time, in case the client has (intentionally or not) little bandwidth. The threads that are receiving the stream of events should never wait for a client to be ready to accept more data before sending a notification to it. If the client isn't ready, then the notification must either be added to a send queue or simply discarded. Because queues must be bounded, it is unavoidable to sometimes have to discard some notifications.
 
-Consequently, all functions that consist in sending notifications must be designed having in mind that the queue of notifications to send out must be bounded to a certain value. For example, the queue of notifications for `transaction_unstable_submitAndWatch` must have a size of 3. When the queue is full, new notifications must overwrite the notifications already in the queue. The design of all JSON-RPC functions should take into account the fact that this shouldn't result in a loss of important information for the JSON-RPC client.
+Consequently, all functions that consist in sending notifications must be designed having in mind that the queue of notifications to send out must be bounded to a certain value. For example, the queue of notifications for `transaction_v1_submitAndWatch` must have a size of 3. When the queue is full, new notifications must overwrite the notifications already in the queue. The design of all JSON-RPC functions should take into account the fact that this shouldn't result in a loss of important information for the JSON-RPC client.
 
 ## Distinguishing between light and heavy calls
 


### PR DESCRIPTION
One remark concerning https://github.com/paritytech/json-rpc-interface-spec/issues/23 is that the `dropped` event can be used if the JSON-RPC client has reached its maximum number of subscriptions. This is already explained in the documentation of the function. There is therefore no need to change anything.
