### PR TITLE
Remove `chainHead_unstable_genesisHash`

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -20,7 +20,6 @@
     - [chainHead_unstable_body](api/chainHead_unstable_body.md)
     - [chainHead_unstable_call](api/chainHead_unstable_call.md)
     - [chainHead_unstable_follow](api/chainHead_unstable_follow.md)
-    - [chainHead_unstable_genesisHash](api/chainHead_unstable_genesisHash.md)
     - [chainHead_unstable_header](api/chainHead_unstable_header.md)
     - [chainHead_unstable_stopBody](api/chainHead_unstable_stopBody.md)
     - [chainHead_unstable_stopCall](api/chainHead_unstable_stopCall.md)

--- a/src/api/chainHead_unstable_genesisHash.md
+++ b/src/api/chainHead_unstable_genesisHash.md
@@ -1,9 +1,0 @@
-# chainHead_unstable_genesisHash
-
-**Parameters**: *none*
-
-**Return value**: String containing the hexadecimal-encoded hash of the genesis block of the chain.
-
-This function is a simple getter. The JSON-RPC server is expected to keep in its memory the hash of the genesis block.
-
-The value returned by this function must never change for the lifetime of the connection between the JSON-RPC client and server.


### PR DESCRIPTION
Since the objective is to stabilize the `chainHead` namespace in the nearby future, this pull request proposes to remove the `chainHead_unstable_genesisHash` JSON-RPC function out of caution.

The reason is that a client that simply follows the head of the chain might not necessarily be aware of what the genesis hash is. See https://github.com/polkadot-fellows/RFCs/pull/8 for an example.
The genesis hash can be found in the chain at `System::BlockHash[0]`, but since this is a runtime-specific thing it should be implemented by the JSON-RPC client on top of `chainHead_storage`, rather than by the server.

Note that `archive_genesisHash` and `chainSpec_genesisHash` still exist, as a node that implements `archive` is clearly supposed to know what the genesis hash is, and that a node that implements `chainSpec` can read the genesis hash from its chain spec.
