### PR TITLE
fix: `inaccessible` event on `chainHead_unstable_call`

### DIFF
--- a/src/api/chainHead_unstable_call.md
+++ b/src/api/chainHead_unstable_call.md
@@ -56,14 +56,11 @@ No more event will be generated with this `subscription`.
 
 ```json
 {
-    "event": "inaccessible",
-    "error": "..."
+    "event": "inaccessible"
 }
 ```
 
 The `inaccessible` event is produced if the JSON-RPC server was incapable of obtaining the storage items necessary for the call.
-
-`error` is a human-readable error message indicating why the call has failed. This string isn't meant to be shown to end users, but is for developers to understand the problem.
 
 Contrary to the `error` event, repeating the same call in the future might succeed.
 


### PR DESCRIPTION
I'm pretty sure that this was a copy/paste mistake as non of the other `inaccessble` events have the `error` property. Also, IMO it doesn't make a lot of sense to have an error property on this event.

cc: @tomaka 