### PR TITLE
chainHead: Standardize `camelCase` for reported events

### DIFF
--- a/src/api/chainHead.md
+++ b/src/api/chainHead.md
@@ -20,11 +20,11 @@ This beginner guide shows how to use the `chainHead` functions in order to know 
 
 4. Call `chainHead_unstable_call` with `hash` equal to the `finalizedBlockHash` you've just retrieved, `function` equal to `Metadata_metadata`, and an empty `callParameters`.
 
-5. If the JSON-RPC server sends back a `{"event": "operation-inaccessible"}` notification, jump back to step 4 to try again. If the JSON-RPC server sends back a `{"event": "operation-error"}` notification, enter panic mode. If the JSON-RPC server instead sends back a `{"event": "operation-call-done"}` notification, save the return value.
+5. If the JSON-RPC server sends back a `{"event": "operationInaccessible"}` notification, jump back to step 4 to try again. If the JSON-RPC server sends back a `{"event": "operationError"}` notification, enter panic mode. If the JSON-RPC server instead sends back a `{"event": "operationCallDone"}` notification, save the return value.
 
 6. The return value you've just saved is called the metadata, prefixed with its SCALE-compact-encoded length. You must decode and parse this metadata. How to do this is out of scope of this small guide. The metadata contains information about the layout of the storage of the chain. Inspect it to determine how to find the storage item you're looking for.
 
-7. In order to obtain a value in the storage, call `chainHead_unstable_storage` with `hash` equal to `finalizedBlockHash`, `key` the desired key, and `type` equal to `value`. If the JSON-RPC server instead sends back a `{"event": "operation-inaccessible"}` notification, the value you're looking for is unfortunately inaccessible and you can either try again or give up. If the JSON-RPC server instead sends back a `{"event": "operation-storage-items"}` notification, you can find the desired value inside.
+7. In order to obtain a value in the storage, call `chainHead_unstable_storage` with `hash` equal to `finalizedBlockHash`, `key` the desired key, and `type` equal to `value`. If the JSON-RPC server instead sends back a `{"event": "operationInaccessible"}` notification, the value you're looking for is unfortunately inaccessible and you can either try again or give up. If the JSON-RPC server instead sends back a `{"event": "operationStorageItems"}` notification, you can find the desired value inside.
 
 8. You are strongly encouraged to maintain [a `Set`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Set) of the blocks where the runtime changes. Whenever a `{"event": "newBlock"}` notification is received with `subscription` equal to your `followSubcriptionId`, and `newRuntime` is non-null, store the provided `blockHash` in this set.
 

--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -41,7 +41,7 @@ For this purpose, each item requested through [`chainHead_unstable_storage`] cou
 
 The JSON-RPC server must start obtaining the body (in other words the list of transactions) of the given block.
 
-The progress of the operation is indicated through `operation-body-done`, `operation-inaccessible`, or `operation-error` notifications generated on the corresponding `chainHead_unstable_follow` subscription.
+The progress of the operation is indicated through `operationBodyDone`, `operationInaccessible`, or `operationError` notifications generated on the corresponding `chainHead_unstable_follow` subscription.
 
 The operation continues even if the target block is unpinned with `chainHead_unstable_unpin`.
 
@@ -49,7 +49,7 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 ## Possible errors
 
-- If the networking part of the behaviour fails, then a `{"event": "operation-inaccessible"}` notification is generated (as explained above).
+- If the networking part of the behaviour fails, then a `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
 - A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.

--- a/src/api/chainHead_unstable_call.md
+++ b/src/api/chainHead_unstable_call.md
@@ -45,7 +45,7 @@ The JSON-RPC server must invoke the entry point of the runtime of the given bloc
 
 **Note**: The runtime is still allowed to call host functions with side effects, however these side effects must be discarded. For example, a runtime function call can try to modify the storage of the chain, but this modification must not be actually applied. The only motivation for performing a call is to obtain the return value.
 
-The progress of the operation is indicated through `operation-call-done`, `operation-inaccessible`, or `operation-error` notifications generated on the corresponding `chainHead_unstable_follow` subscription.
+The progress of the operation is indicated through `operationCallDone`, `operationInaccessible`, or `operationError` notifications generated on the corresponding `chainHead_unstable_follow` subscription.
 
 The operation continues even if the target block is unpinned with `chainHead_unstable_unpin`.
 
@@ -55,13 +55,13 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 ## Possible errors
 
-- If the networking part of the behaviour fails, then an `{"event": "operation-inaccessible"}` notification is generated (as explained above).
+- If the networking part of the behaviour fails, then an `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `̀false`.
 - A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
 - A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.
-- If the method to call doesn't exist in the Wasm runtime of the chain, then an `{"event": "operation-error"}` notification is generated.
-- If the runtime call fails (e.g. because it triggers a panic in the runtime, running out of memory, etc., or if the runtime call takes too much time), then an `{"event": "operation-error"}` notification is generated.
+- If the method to call doesn't exist in the Wasm runtime of the chain, then an `{"event": "operationError"}` notification is generated.
+- If the runtime call fails (e.g. because it triggers a panic in the runtime, running out of memory, etc., or if the runtime call takes too much time), then an `{"event": "operationError"}` notification is generated.
 
 ## About `callParameters`
 

--- a/src/api/chainHead_unstable_continue.md
+++ b/src/api/chainHead_unstable_continue.md
@@ -7,10 +7,10 @@
 
 **Return value**: *null*
 
-Resumes a storage fetch started with `chainHead_unstable_storage` after it has generated an `operation-waiting-for-continue` event.
+Resumes a storage fetch started with `chainHead_unstable_storage` after it has generated an `operationWaitingForContinue` event.
 
-Has no effect if the `operationId` is invalid or refers to an operation that has emitted a `{"event": "operation-inaccessible"}` event, or if the `followSubscription` is invalid or stale.
+Has no effect if the `operationId` is invalid or refers to an operation that has emitted a `{"event": "operationInaccessible"}` event, or if the `followSubscription` is invalid or stale.
 
 ## Possible errors
 
-- A JSON-RPC error is generated if the `followSubscription` and `operationId` are valid but haven't generated a `operation-waiting-for-continue` event.
+- A JSON-RPC error is generated if the `followSubscription` and `operationId` are valid but haven't generated a `operationWaitingForContinue` event.

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -129,11 +129,11 @@ All items in `finalizedBlockHashes` and `prunedBlockHashes` are guaranteed to ha
 
 The current best block, in other words the last block reported through a `bestBlockChanged` event, is guaranteed to either be the last item in `finalizedBlockHashes`, or to not be present in either `finalizedBlockHashes` or `prunedBlockHashes`.
 
-### operation-body-done
+### operationBodyDone
 
 ```json
 {
-    "event": "operation-body-done",
+    "event": "operationBodyDone",
     "operationId": ...,
     "value": [...]
 }
@@ -141,7 +141,7 @@ The current best block, in other words the last block reported through a `bestBl
 
 `operationId` is a string returned by `chainHead_unstable_body`.
 
-The `operation-body-done` event indicates that an operation started with `chainHead_unstable_body` was successful.
+The `operationBodyDone` event indicates that an operation started with `chainHead_unstable_body` was successful.
 
 `value` is an array of strings containing the hexadecimal-encoded SCALE-encoded extrinsics found in the block.
 
@@ -149,11 +149,11 @@ The `operation-body-done` event indicates that an operation started with `chainH
 
 No more event will be generated with this `operationId`.
 
-### operation-call-done
+### operationCallDone
 
 ```json
 {
-    "event": "operation-call-done",
+    "event": "operationCallDone",
     "operationId": ...,
     "output": "0x0000000..."
 }
@@ -161,24 +161,24 @@ No more event will be generated with this `operationId`.
 
 `operationId` is a string returned by`chainHead_unstable_call`.
 
-The `operation-call-done` event indicates that an operation started with `chainHead_unstable_call` was successful.
+The `operationCallDone` event indicates that an operation started with `chainHead_unstable_call` was successful.
 
 `output` is the hexadecimal-encoded output of the runtime function call.
 
 No more event will be generated with this `operationId`.
 
-### operation-storage-items
+### operationStorageItems
 
 ```json
 {
-    "event": "operation-storage-items",
+    "event": "operationStorageItems",
     "operationId": ...,
     "items": [
         {
             "key": "0x0000000...",
             "value": "0x0000000...",
             "hash": "0x0000000...",
-            "closest-descendant-merkle-value": "0x000000..."
+            "closestDescendantMerkleValue": "0x000000..."
         },
         ...
     ]
@@ -190,72 +190,72 @@ No more event will be generated with this `operationId`.
 Yields one or more items that were found in the storage.
 
 The `key` field is a string containing the hexadecimal-encoded key of the item. This `key` is guaranteed to start with one of the `key`s provided as parameter to `chainHead_unstable_storage`.
-If the `type` parameter was `"value"`, `"hash"`, `"closest-descendant-merkle-value"`, then it is also guaranteed to be equal to one of the `key`s provided as parameter to `chainHead_unstable_storage`.
+If the `type` parameter was `"value"`, `"hash"`, `"closestDescendantMerkleValue"`, then it is also guaranteed to be equal to one of the `key`s provided as parameter to `chainHead_unstable_storage`.
 
-In the situation where the `type` parameter was `"closest-descendant-merkle-value"`, the fact that `key` is equal to a `key` that was provided as parameter is necessary in order to avoid ambiguities when multiple `items` of type `"closest-descendant-merkle-value"` were requested.
+In the situation where the `type` parameter was `"closestDescendantMerkleValue"`, the fact that `key` is equal to a `key` that was provided as parameter is necessary in order to avoid ambiguities when multiple `items` of type `"closestDescendantMerkleValue"` were requested.
 
-The `value` field is set if this item corresponds to one of the requested items whose `type` was `"value"` or `"descendants-values"`. The `value` field is a string containing the hexadecimal-encoded value of the storage entry.
+The `value` field is set if this item corresponds to one of the requested items whose `type` was `"value"` or `"descendantsValues"`. The `value` field is a string containing the hexadecimal-encoded value of the storage entry.
 
-The `hash` field is set if this item corresponds to one of the requested items whose `type` was `"hash"` or `"descendants-hashes"`. The `hash` field is a string containing the hexadecimal-encoded hash of the storage entry.
+The `hash` field is set if this item corresponds to one of the requested items whose `type` was `"hash"` or `"descendantsHashes"`. The `hash` field is a string containing the hexadecimal-encoded hash of the storage entry.
 
-The `closest-descendant-merkle-value` field is set if this item corresponds to one of the requested items whose `type` was `"closest-descendant-merkle-value"`. The trie node whose Merkle value is indicated in `closest-descendant-merkle-value` is not indicated, as determining the key of this node might incur an overhead for the JSON-RPC server.
+The `closestDescendantMerkleValue` field is set if this item corresponds to one of the requested items whose `type` was `"closestDescendantMerkleValue"`. The trie node whose Merkle value is indicated in `closestDescendantMerkleValue` is not indicated, as determining the key of this node might incur an overhead for the JSON-RPC server.
 
-### operation-waiting-for-continue
+### operationWaitingForContinue
 
 ```json
 {
-    "event": "operation-waiting-for-continue",
+    "event": "operationWaitingForContinue",
     "operationId": ...
 }
 ```
 
 `operationId` is a string returned by `chainHead_unstable_storage`.
 
-The `waiting-for-continue` event is generated after at least one `"operation-storage-items"` event has been generated, and indicates that the JSON-RPC client must call `chainHead_unstable_continue` before more events are generated.
+The `waiting-for-continue` event is generated after at least one `"operationStorageItems"` event has been generated, and indicates that the JSON-RPC client must call `chainHead_unstable_continue` before more events are generated.
 
-This event only ever happens if the `type` parameter that was provided to `chainHead_unstable_storage` was `descendants-values` or `descendants-hashes`.
+This event only ever happens if the `type` parameter that was provided to `chainHead_unstable_storage` was `descendantsValues` or `descendantsHashes`.
 
-While the JSON-RPC server is waiting for a call to `chainHead_unstable_continue`, it can generate an `operation-inaccessible` event in order to indicate that it can no longer proceed with the operation. If that is the case, the JSON-RPC client can simply try again.
+While the JSON-RPC server is waiting for a call to `chainHead_unstable_continue`, it can generate an `operationInaccessible` event in order to indicate that it can no longer proceed with the operation. If that is the case, the JSON-RPC client can simply try again.
 
-### operation-storage-done
+### operationStorageDone
 
 ```json
 {
-    "event": "operation-storage-done",
+    "event": "operationStorageDone",
     "operationId": ...
 }
 ```
 
 `operationId` is a string returned by `chainHead_unstable_storage`.
 
-The `operation-storage-done` event indicates that an operation started with `chainHead_unstable_storage` went well and all result has been provided through `operation-storage-items` events in the past.
+The `operationStorageDone` event indicates that an operation started with `chainHead_unstable_storage` went well and all result has been provided through `operationStorageItems` events in the past.
 
-If no `operation-storage-items` event was yielded for this `operationId`, then the storage doesn't contain a value at the given key.
+If no `operationStorageItems` event was yielded for this `operationId`, then the storage doesn't contain a value at the given key.
 
 No more event will be generated with this `operationId`.
 
-### operation-inaccessible
+### operationInaccessible
 
 ```json
 {
-    "event": "operation-inaccessible",
+    "event": "operationInaccessible",
     "operationId": ...
 }
 ```
 
 `operationId` is a string returned by `chainHead_unstable_body`, `chainHead_unstable_call`, or `chainHead_unstable_storage`.
 
-The `operation-inaccessible` event is produced if the JSON-RPC server was incapable of obtaining the storage items necessary for the given operation.
+The `operationInaccessible` event is produced if the JSON-RPC server was incapable of obtaining the storage items necessary for the given operation.
 
-Contrary to the `operation-error` event, repeating the same operation in the future might succeed.
+Contrary to the `operationError` event, repeating the same operation in the future might succeed.
 
 No more event will be generated about this `operationId`.
 
-### operation-error
+### operationError
 
 ```json
 {
-    "event": "operation-error",
+    "event": "operationError",
     "operationId": ...,
     "error": "..."
 }
@@ -263,9 +263,9 @@ No more event will be generated about this `operationId`.
 
 `operationId` is a string returned by `chainHead_unstable_body`, `chainHead_unstable_call`, or `chainHead_unstable_storage`.
 
-The `operation-error` event indicates a problem during the operation. In the case of `chainHead_unstable_call`, this can include the function missing or a runtime panic. In the case of `chainHead_unstable_body` or `chainHead_unstable_storage`, this includes failing to parse the block header to obtain the extrinsics root hash or state root hash.
+The `operationError` event indicates a problem during the operation. In the case of `chainHead_unstable_call`, this can include the function missing or a runtime panic. In the case of `chainHead_unstable_body` or `chainHead_unstable_storage`, this includes failing to parse the block header to obtain the extrinsics root hash or state root hash.
 
-Contrary to the `operation-inaccessible` event, repeating the same call in the future will not succeed.
+Contrary to the `operationInaccessible` event, repeating the same call in the future will not succeed.
 
 `error` is a human-readable error message indicating why the call has failed. This string isn't meant to be shown to end users, but is for developers to understand the problem.
 

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -10,7 +10,7 @@
 Each element in `items` must be an object containing the following fields:
 
 - `key`: String containing the hexadecimal-encoded key to fetch in the storage.
-- `type`: String equal to one of: `value`, `hash`, `closest-descendant-merkle-value`, `descendants-values`, `descendants-hashes`.
+- `type`: String equal to one of: `value`, `hash`, `closestDescendantMerkleValue`, `descendantsValues`, `descendantsHashes`.
 
 **Return value**: A JSON object.
 
@@ -50,36 +50,36 @@ This return value indicates that all the items would be discarded, or that the p
 
 ## Overview
 
-For each item in `items`, the JSON-RPC server must start obtaining the value of the entry with the given `key` from the storage, either from the main trie or from `childTrie`. If `type` is `descendants-values` or `descendants-hashes`, then it must also obtain the values of all the descendants of the entry.
+For each item in `items`, the JSON-RPC server must start obtaining the value of the entry with the given `key` from the storage, either from the main trie or from `childTrie`. If `type` is `descendantsValues` or `descendantsHashes`, then it must also obtain the values of all the descendants of the entry.
 
 For the purpose of storage requests, the trie root hash of the child tries of the storage can be found in the main trie at keys starting the bytes of the ASCII string `:child_storage:`. This behaviour is consistent with all the other storage-request-alike mechanisms of Polkadot and Substrate-based chains, such as host functions or libp2p network requests.
 
-The progress of the operation is indicated through `operation-storage-items`, `operation-waiting-for-continue`, `operation-storage-done`, `operation-inaccessible`, or `operation-error` notifications generated on the corresponding `chainHead_unstable_follow` subscription.
+The progress of the operation is indicated through `operationStorageItems`, `operationWaitingForContinue`, `operationStorageDone`, `operationInaccessible`, or `operationError` notifications generated on the corresponding `chainHead_unstable_follow` subscription.
 
 The operation continues even if the target block is unpinned with `chainHead_unstable_unpin`.
 
 This function should be seen as a complement to `chainHead_unstable_follow`, allowing the JSON-RPC client to retrieve more information about a block that has been reported. Use `archive_unstable_storage` if instead you want to retrieve the storage of an arbitrary block.
 
-`{"event": "operation-storage-items"}` notifications will be generated. Each notification contains a list of items. The list of items, concatenated together, forms the result.
+`{"event": "operationStorageItems"}` notifications will be generated. Each notification contains a list of items. The list of items, concatenated together, forms the result.
 
 If the `type` of an item is `value`, and `key` is associated with a storage value in the trie, then the result will include an item that contains this storage value. If `key` is not associated with a storage value in the trie, then the result will not include such item.
 
 If the `type` of an item is `hash`, the behaviour is similar to a `type` equal to `value`, except that the cryptographic hash of the value is included in the result rather than the value itself. The hashing algorithm used is the one of the chain, which is typically blake2b. This can lead to significantly less bandwidth usage and can be used in order to compare the value of an item with a known hash and querying the full value only if it differs.
 
-If the `type` of an item is `descendants-values` or `descendants-hashes`, then the result will contain zero or more items whose key starts with the `key` of this item.
+If the `type` of an item is `descendantsValues` or `descendantsHashes`, then the result will contain zero or more items whose key starts with the `key` of this item.
 
-If the `type` of an item is `closest-descendant-merkle-value`, then the so-called trie Merkle value of the `key` can be found in the result. If `key` doesn't exist in the trie, then the Merkle value of the closest descendant of `key` (including branch nodes) is provided. If `key` doesn't have any descendant in the trie, then the result will not contain any relevant item.
+If the `type` of an item is `closestDescendantMerkleValue`, then the so-called trie Merkle value of the `key` can be found in the result. If `key` doesn't exist in the trie, then the Merkle value of the closest descendant of `key` (including branch nodes) is provided. If `key` doesn't have any descendant in the trie, then the result will not contain any relevant item.
 
 If `items` contains multiple identical or overlapping queries, the JSON-RPC server can choose whether to merge or not the items in the result. For example, if the request contains two items with the same key, one with `hash` and one with `value`, the JSON-RPC server can choose whether to generate two `item` objects, one with the value and one with the hash, or only a single `item` object with both `hash` and `value` set. The JSON-RPC server is encouraged to notify as soon as possible of the information at its disposal, without waiting for missing information.
 
 It is allowed (but discouraged) for the JSON-RPC server to provide the same information multiple times in the result, for example providing the `value` field of the same `key` twice. Forcing the JSON-RPC server to de-duplicate items in the result might lead to unnecessary overhead.
 
-If a `{"event": "operation-waiting-for-continue"}` notification is generated, the subscription will not generate any more notification unless the JSON-RPC client calls the `chainHead_unstable_continue` JSON-RPC function. The JSON-RPC server is encouraged to generate this event after having sent a certain number of bytes to the JSON-RPC client in order to avoid head-of-line-blocking issues.
+If a `{"event": "operationWaitingForContinue"}` notification is generated, the subscription will not generate any more notification unless the JSON-RPC client calls the `chainHead_unstable_continue` JSON-RPC function. The JSON-RPC server is encouraged to generate this event after having sent a certain number of bytes to the JSON-RPC client in order to avoid head-of-line-blocking issues.
 
 ## Possible errors
 
 - A JSON-RPC error is generated if `type` isn't one of the allowed values (similarly to a missing parameter or an invalid parameter type).
-- If the networking part of the behaviour fails, then a `{"event": "operation-inaccessible"}` notification is generated (as explained above).
+- If the networking part of the behaviour fails, then a `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
 - A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.


### PR DESCRIPTION
This changes all related events from the kebab-case naming convention to camelCase.

Closes: https://github.com/paritytech/json-rpc-interface-spec/issues/74

// cc @tomaka @josepot @jsdw 