### PR TITLE
explicit guarantees on the `finalized` event of `submitAndWatch`

### DIFF
--- a/src/api/transaction_unstable_submitAndWatch.md
+++ b/src/api/transaction_unstable_submitAndWatch.md
@@ -105,7 +105,7 @@ If multiple `bestChainBlockIncluded` events happen in a row, the JSON-RPC server
 }
 ```
 
-The `finalized` event indicates that this transaction is present in a block of the chain that is finalized.
+The `finalized` event indicates that the latest block that was previously reported with `bestChainBlockIncluded` is now finalized.
 
 `hash` is a string containing the hexadecimal-encoded hash of the header of the block. `index` is a string containing an integer indicating the 0-based index of this transaction within the body of this block.
 

--- a/src/api/transaction_unstable_submitAndWatch.md
+++ b/src/api/transaction_unstable_submitAndWatch.md
@@ -111,6 +111,8 @@ The `finalized` event indicates that the latest block that was previously report
 
 No more event will be generated about this transaction.
 
+**Note**: Please note that when this event occurs, the `bestChainBlockIncluded` event always precedes the `finalized` event of `chainHead_unstable_follow`, which includes the block hash from `bestChainBlockIncluded` in its list of `finalizedBlockHashes`.
+
 ### error
 
 ```json


### PR DESCRIPTION
While working on the higher-level abstraction for submitting transactions, I realized that if the node also implements the `chainHead` functions, I don't need to stress about the `finalized` event in `transaction_unstable_submitAndWatch`. I'd rather have one reliable source of information than juggle two that need to sync.

What I really need is to be sure that when the `finalized` event happens, the block in that event matches the latest one from the `bestChainBlockIncluded` event. So, I'd like the spec to be clear about this. It just makes things simpler and more foolproof.

cc: @tomaka 

EDIT: I'd also like to have the guarantee that if the node implements the `chainHead` functions, the `bestChainBlockIncluded` event from `submitAndWatch` will come before the `chainHead` `finalized` event which includes that block in its list of `finalizedBlockHashes`. (I just added a second commit with a note to be explicit about this guarantee).