### PR TITLE
archive: Use integer for describing block height

### DIFF
--- a/src/api/archive_unstable_finalizedHeight.md
+++ b/src/api/archive_unstable_finalizedHeight.md
@@ -2,7 +2,7 @@
 
 **Parameters**: *none*
 
-**Return value**: String containing the hexadecimal-encoded height of the current finalized block of the chain.
+**Return value**: An integer height of the current finalized block of the chain.
 
 The value returned by this function must only ever increase over time. In other words, if calling this function returns `N`, then calling it again later must return a value superior or equal to `N`.
 

--- a/src/api/archive_unstable_hashByHeight.md
+++ b/src/api/archive_unstable_hashByHeight.md
@@ -2,7 +2,7 @@
 
 **Parameters**:
 
-- `height`: Is an integer representing the height of the block.
+- `height`: Integer representing the height of the block.
 
 **Return value**: Array (possibly empty) of strings containing an hexadecimal-encoded hash of a block header.
 

--- a/src/api/archive_unstable_hashByHeight.md
+++ b/src/api/archive_unstable_hashByHeight.md
@@ -2,7 +2,7 @@
 
 **Parameters**:
 
-- `height`: String containing an hexadecimal-encoded integer.
+- `height`: Is an integer representing the height of the block.
 
 **Return value**: Array (possibly empty) of strings containing an hexadecimal-encoded hash of a block header.
 


### PR DESCRIPTION
This PR changes the return value and parameters from using a string containing an integer to a plain integer.

This change reflects: https://github.com/paritytech/json-rpc-interface-spec/pull/84

cc @tomaka @jsdw @josepot @paritytech/subxt-team 