### PR TITLE
archive: Use camelCase for waitingForContinue event

### DIFF
--- a/src/api/archive_unstable_storageContinue.md
+++ b/src/api/archive_unstable_storageContinue.md
@@ -6,10 +6,10 @@
 
 **Return value**: *null*
 
-Resumes a storage fetch started with `archive_unstable_storage` after it has generated a `waiting-for-continue` event.
+Resumes a storage fetch started with `archive_unstable_storage` after it has generated a `waitingForContinue` event.
 
 Has no effect if the `subscription` is invalid or refers to a subscription that has emitted a `{"event": "stop"}` event.
 
 ## Possible errors
 
-- A JSON-RPC error is generated if the `subscription` is valid but hasn't generated a `waiting-for-continue` event.
+- A JSON-RPC error is generated if the `subscription` is valid but hasn't generated a `waitingForContinue` event.

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -213,7 +213,7 @@ The `closestDescendantMerkleValue` field is set if this item corresponds to one 
 
 `operationId` is a string returned by `chainHead_unstable_storage`.
 
-The `waiting-for-continue` event is generated after at least one `"operationStorageItems"` event has been generated, and indicates that the JSON-RPC client must call `chainHead_unstable_continue` before more events are generated.
+The `waitingForContinue` event is generated after at least one `"operationStorageItems"` event has been generated, and indicates that the JSON-RPC client must call `chainHead_unstable_continue` before more events are generated.
 
 This event only ever happens if the `type` of one of the `items` provided as a parameter to `chainHead_unstable_storage` was `descendantsValues` or `descendantsHashes`.
 


### PR DESCRIPTION
For consistency with generated events, the `waiting-for-continue`
description is now using camalCase convention.

cc @tomaka @jsdw @josepot @paritytech/subxt-team 