### PR TITLE
archive/body: Keep description consistent with chainHead

### DIFF
--- a/src/api/archive_unstable_body.md
+++ b/src/api/archive_unstable_body.md
@@ -2,7 +2,7 @@
 
 **Parameters**:
 
-- `hash`: String containing the hexadecimal-encoded hash of the header of the block whose body must be retrieved.
+- `hash`: String containing an hexadecimal-encoded hash of the header of the block whose body to fetch.
 
 **Return value**: If a block with that hash is found, an array of strings containing the hexadecimal-encoded SCALE-codec-encoded transactions in that block. If no block with that hash is found, `null`.
 

--- a/src/api/archive_unstable_body.md
+++ b/src/api/archive_unstable_body.md
@@ -2,7 +2,7 @@
 
 **Parameters**:
 
-- `hash`: String containing an hexadecimal-encoded hash of the header of the block whose body to fetch.
+- `hash`: String containing a hexadecimal-encoded hash of the header of the block whose body will be retrieved.
 
 **Return value**: If a block with that hash is found, an array of strings containing the hexadecimal-encoded SCALE-codec-encoded transactions in that block. If no block with that hash is found, `null`.
 

--- a/src/api/archive_unstable_hashByHeight.md
+++ b/src/api/archive_unstable_hashByHeight.md
@@ -2,9 +2,9 @@
 
 **Parameters**:
 
-- `height`: String containing an hexadecimal-encoded integer.
+- `height`: String containing a hexadecimal-encoded integer.
 
-**Return value**: Array (possibly empty) of strings containing an hexadecimal-encoded hash of a block header.
+**Return value**: Array (possibly empty) of strings containing a hexadecimal-encoded hash of a block header.
 
 The JSON-RPC client must find the blocks (zero, one, or more) whose height is the one passed as parameter. If the `height` is inferior or equal to the finalized block height, then only finalized blocks must be fetched and returned.
 

--- a/src/api/archive_unstable_storage.md
+++ b/src/api/archive_unstable_storage.md
@@ -2,7 +2,7 @@
 
 **Parameters**:
 
-- `hash`: String containing an hexadecimal-encoded hash of the header of the block whose storage to fetch.
+- `hash`: String containing a hexadecimal-encoded hash of the header of the block whose storage to fetch.
 - `key`: String containing the hexadecimal-encoded key to fetch in the storage.
 - `childTrie`: `null` for main storage look-ups, or a string containing the hexadecimal-encoded key of the child trie of the "default" namespace.
 - `includeDescendants`: Boolean indicating whether the key-values of all the descendants of the `key` should be returned as well.

--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -3,7 +3,7 @@
 **Parameters**:
 
 - `followSubscription`: An opaque string that was returned by `chainHead_unstable_follow`.
-- `hash`: String containing an hexadecimal-encoded hash of the header of the block whose body to fetch.
+- `hash`: String containing a hexadecimal-encoded hash of the header of the block whose body will be retrieved.
 
 **Return value**: A JSON object.
 

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -3,7 +3,7 @@
 **Parameters**:
 
 - `followSubscription`: An opaque string that was returned by `chainHead_unstable_follow`.
-- `hash`: String containing an hexadecimal-encoded hash of the header of the block whose storage to fetch.
+- `hash`: String containing a hexadecimal-encoded hash of the header of the block whose storage to fetch.
 - `items`: Array of objects. The structure of these objects is found below.
 - `childTrie`: `null` for main storage look-ups, or a string containing the hexadecimal-encoded key of the child trie of the "default" namespace.
 


### PR DESCRIPTION
This PR uses the same description for the `hash` parameter as the one from the `chainHead`.

cc @tomaka @jsdw @josepot @paritytech/subxt-team 