### PR TITLE
Use the same method name for notification results

### DIFF
--- a/src/api/archive_unstable_storage.md
+++ b/src/api/archive_unstable_storage.md
@@ -22,7 +22,7 @@ This function will later generate notifications in the following format:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "archive_unstable_storageEvent",
+    "method": "archive_unstable_storage",
     "params": {
         "subscription": "...",
         "result": ...

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -47,7 +47,7 @@ This function will later generate one or more notifications in the following for
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "chainHead_unstable_followEvent",
+    "method": "chainHead_unstable_follow",
     "params": {
         "subscription": "...",
         "result": ...

--- a/src/api/transaction_unstable_submitAndWatch.md
+++ b/src/api/transaction_unstable_submitAndWatch.md
@@ -17,7 +17,7 @@ This function will later generate one or more notifications in the following for
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "transaction_unstable_watchEvent",
+    "method": "transaction_unstable_submitAndWatch",
     "params": {
         "subscription": "...",
         "result": ...


### PR DESCRIPTION
Currently, there's a method suffixed with `Event` that generates JSON-RPC notifications (ie subscription results).
For example, the subscription events generated by calling `chainHead_unstable_follow` are provided under `"method": "chainHead_unstable_followEvent"`.


This PR aligns the method name of the subscription that generates notifications with the method called, keeping parity with Substrate (pub/sub model used).
Also, it is not possible to configure this in [jsonrpsee](https://github.com/paritytech/jsonrpsee/blob/96c035c56094606fe98b98f9a033cced32781d04/core/src/server/rpc_module.rs#L283-L286).


Would love to hear your thoughts 🙏 

cc @tomaka @josepot @jsdw @paritytech/subxt-team 