### PR TITLE
Tiny clarification in rpc_methods

### DIFF
--- a/src/api/rpc_methods.md
+++ b/src/api/rpc_methods.md
@@ -2,4 +2,4 @@
 
 **Parameters**: *none*
 
-**Return value**: Array of strings indicating the names of all the JSON-RPC functions supported by the JSON-RPC server.
+**Return value**: Array of strings indicating the names of all the JSON-RPC functions supported by the JSON-RPC server, including this one.


### PR DESCRIPTION
Just a tiny clarification to address this sort of thing https://github.com/paritytech/polkadot-sdk/issues/1627.

The spec does already say "all names", but I thought it'd be good to emphasise this particular point