### PR TITLE
chainHead/unpin: Explicit about unpin parameters

### DIFF
--- a/src/api/chainHead_unstable_unpin.md
+++ b/src/api/chainHead_unstable_unpin.md
@@ -3,7 +3,7 @@
 **Parameters**:
 
 - `followSubscription`: An opaque string that was returned by `chainHead_unstable_follow`.
-- `hash`: String or array of strings containing the hexadecimal-encoded hash of the header of the block to unpin.
+- `hash_or_hashes`: String or array of strings containing the hexadecimal-encoded hash of the header of the block to unpin.
 
 **Return value**: *null*
 


### PR DESCRIPTION
This PR renames the parameter of the unpin method from `hash` to `hash_or_hashes` to suggest to the users that it can be one of two different formats: plain hex or array of hexes.

Another approach to clarify this would be to change the `hash` parameter to `hashes` and accept only an array of hex-encoded hashes. 

// cc @paritytech/subxt-team @josepot @tomaka 