### PR TITLE
Change the error code returned by `chainHead_follow`

### DIFF
--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -399,4 +399,4 @@ The runtime is of type `invalid` if the JSON-RPC server considers the runtime as
 
 ## Possible errors
 
-- A JSON-RPC error with error code `-32100` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.
+- A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.


### PR DESCRIPTION
As mentioned in the spec (https://www.jsonrpc.org/specification#error_object), -32100 is actually reserved.
Let's use a non-reserved error code.