### PR TITLE
chainHead: Define error codes returned by the server

### DIFF
--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -51,5 +51,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 - If the networking part of the behaviour fails, then a `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
-- A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
-- A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.
+- A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.

--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -53,4 +53,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
-- A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).
+- A JSON-RPC error with error code `-32603` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).

--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -52,5 +52,5 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the networking part of the behaviour fails, then a `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 - A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).

--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -53,3 +53,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).

--- a/src/api/chainHead_unstable_body.md
+++ b/src/api/chainHead_unstable_body.md
@@ -52,3 +52,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the networking part of the behaviour fails, then a `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_call.md
+++ b/src/api/chainHead_unstable_call.md
@@ -61,6 +61,7 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the runtime call fails (e.g. because it triggers a panic in the runtime, running out of memory, etc., or if the runtime call takes too much time), then an `{"event": "operationError"}` notification is generated.
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32802` is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `̀false`.
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 
 ## About `callParameters`
 

--- a/src/api/chainHead_unstable_call.md
+++ b/src/api/chainHead_unstable_call.md
@@ -57,11 +57,10 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 - If the networking part of the behaviour fails, then an `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
-- A JSON-RPC error is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `̀false`.
-- A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
-- A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.
 - If the method to call doesn't exist in the Wasm runtime of the chain, then an `{"event": "operationError"}` notification is generated.
 - If the runtime call fails (e.g. because it triggers a panic in the runtime, running out of memory, etc., or if the runtime call takes too much time), then an `{"event": "operationError"}` notification is generated.
+- A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
+- A JSON-RPC error with error code `-32802` is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `̀false`.
 
 ## About `callParameters`
 

--- a/src/api/chainHead_unstable_call.md
+++ b/src/api/chainHead_unstable_call.md
@@ -60,7 +60,7 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the method to call doesn't exist in the Wasm runtime of the chain, then an `{"event": "operationError"}` notification is generated.
 - If the runtime call fails (e.g. because it triggers a panic in the runtime, running out of memory, etc., or if the runtime call takes too much time), then an `{"event": "operationError"}` notification is generated.
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
-- A JSON-RPC error with error code `-32802` is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `̀false`.
+- A JSON-RPC error with error code `-32802` is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `false`.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 
 ## About `callParameters`

--- a/src/api/chainHead_unstable_call.md
+++ b/src/api/chainHead_unstable_call.md
@@ -61,7 +61,7 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 - If the runtime call fails (e.g. because it triggers a panic in the runtime, running out of memory, etc., or if the runtime call takes too much time), then an `{"event": "operationError"}` notification is generated.
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32802` is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `̀false`.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 
 ## About `callParameters`
 

--- a/src/api/chainHead_unstable_continue.md
+++ b/src/api/chainHead_unstable_continue.md
@@ -14,3 +14,4 @@ Has no effect if the `operationId` is invalid or refers to an operation that has
 ## Possible errors
 
 - A JSON-RPC error with error code `-32803` is generated if the `followSubscription` and `operationId` are valid but haven't generated a `operationWaitingForContinue` event.
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_continue.md
+++ b/src/api/chainHead_unstable_continue.md
@@ -13,4 +13,4 @@ Has no effect if the `operationId` is invalid or refers to an operation that has
 
 ## Possible errors
 
-- A JSON-RPC error is generated if the `followSubscription` and `operationId` are valid but haven't generated a `operationWaitingForContinue` event.
+- A JSON-RPC error with error code `-32803` is generated if the `followSubscription` and `operationId` are valid but haven't generated a `operationWaitingForContinue` event.

--- a/src/api/chainHead_unstable_continue.md
+++ b/src/api/chainHead_unstable_continue.md
@@ -14,4 +14,4 @@ Has no effect if the `operationId` is invalid or refers to an operation that has
 ## Possible errors
 
 - A JSON-RPC error with error code `-32803` is generated if the `followSubscription` and `operationId` are valid but haven't generated a `operationWaitingForContinue` event.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -400,3 +400,4 @@ The runtime is of type `invalid` if the JSON-RPC server considers the runtime as
 ## Possible errors
 
 - A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -401,4 +401,3 @@ The runtime is of type `invalid` if the JSON-RPC server considers the runtime as
 
 - A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
-- A JSON-RPC error with error code `-32603` is generated if the JSON-RPC server was unable of generating a valid subscription ID.

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -401,4 +401,4 @@ The runtime is of type `invalid` if the JSON-RPC server considers the runtime as
 
 - A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
-- A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server was unable of generating a valid subscription ID.
+- A JSON-RPC error with error code `-32603` is generated if the JSON-RPC server was unable of generating a valid subscription ID.

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -401,3 +401,4 @@ The runtime is of type `invalid` if the JSON-RPC server considers the runtime as
 
 - A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.
 - A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server was unable of generating a valid subscription ID.

--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -400,5 +400,5 @@ The runtime is of type `invalid` if the JSON-RPC server considers the runtime as
 ## Possible errors
 
 - A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 2 or more `chainHead_unstable_follow` subscriptions.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 - A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server was unable of generating a valid subscription ID.

--- a/src/api/chainHead_unstable_header.md
+++ b/src/api/chainHead_unstable_header.md
@@ -19,5 +19,5 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 ## Possible errors
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 - A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).

--- a/src/api/chainHead_unstable_header.md
+++ b/src/api/chainHead_unstable_header.md
@@ -18,5 +18,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 ## Possible errors
 
-- A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
-- A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.
+- A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.

--- a/src/api/chainHead_unstable_header.md
+++ b/src/api/chainHead_unstable_header.md
@@ -20,4 +20,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
-- A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).
+- A JSON-RPC error with error code `-32603` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).

--- a/src/api/chainHead_unstable_header.md
+++ b/src/api/chainHead_unstable_header.md
@@ -19,3 +19,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 ## Possible errors
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_header.md
+++ b/src/api/chainHead_unstable_header.md
@@ -20,3 +20,4 @@ This function should be seen as a complement to `chainHead_unstable_follow`, all
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32805` is generated if the JSON-RPC server cannot interpret the block (hardware issues, corrupted database, disk failure etc).

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -82,4 +82,4 @@ If a `{"event": "operationWaitingForContinue"}` notification is generated, the s
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -78,8 +78,8 @@ If a `{"event": "operationWaitingForContinue"}` notification is generated, the s
 
 ## Possible errors
 
-- A JSON-RPC error is generated if `type` isn't one of the allowed values (similarly to a missing parameter or an invalid parameter type).
 - If the networking part of the behaviour fails, then a `{"event": "operationInaccessible"}` notification is generated (as explained above).
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
-- A JSON-RPC error is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
-- A JSON-RPC error is generated if the `followSubscription` is valid but the block hash passed as parameter has already been unpinned.
+
+- A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
+- A JSON-RPC error with error code `-32804` is generated if `type` isn't one of the allowed values (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -82,4 +82,4 @@ If a `{"event": "operationWaitingForContinue"}` notification is generated, the s
 - If the `followSubscription` is invalid or stale, then `"result": "limitReached"` is returned (as explained above).
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
-- A JSON-RPC error with error code `-32804` is generated if `type` isn't one of the allowed values (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).

--- a/src/api/chainHead_unstable_unpin.md
+++ b/src/api/chainHead_unstable_unpin.md
@@ -18,4 +18,5 @@ If this function returns an error, then no block has been unpinned. An JSON-RPC 
 ## Possible errors
 
 - A JSON-RPC error with error code `-32801` is generated if the `followSubscription` is valid but at least one of the block hashes passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or at least one of the block hashes has been unpinned.
+- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 - No error is generated if the `followSubscription` is invalid or stale. The call is simply ignored.

--- a/src/api/chainHead_unstable_unpin.md
+++ b/src/api/chainHead_unstable_unpin.md
@@ -17,6 +17,5 @@ If this function returns an error, then no block has been unpinned. An JSON-RPC 
 
 ## Possible errors
 
-- A JSON-RPC error is generated if the `followSubscription` is valid but at least one of the block hashes passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`.
-- A JSON-RPC error is generated if the `followSubscription` is valid but at least one of the the block hashes passed as parameter has already been unpinned.
+- A JSON-RPC error with error code `-32801` is generated if the `followSubscription` is valid but at least one of the block hashes passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or at least one of the block hashes has been unpinned.
 - No error is generated if the `followSubscription` is invalid or stale. The call is simply ignored.

--- a/src/api/chainHead_unstable_unpin.md
+++ b/src/api/chainHead_unstable_unpin.md
@@ -18,5 +18,5 @@ If this function returns an error, then no block has been unpinned. An JSON-RPC 
 ## Possible errors
 
 - A JSON-RPC error with error code `-32801` is generated if the `followSubscription` is valid but at least one of the block hashes passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or at least one of the block hashes has been unpinned.
-- A JSON-RPC error with error code `-32804` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 - No error is generated if the `followSubscription` is invalid or stale. The call is simply ignored.


### PR DESCRIPTION
This PR defined the error codes returned by the server:
- `-32800` two or more subscriptions requested for chainHead_follow
- `-32801` block hash not reported by chainHead_follow or block hash has been unpinned
- `-32802` chainHead_follow started with withRuntime == false
- `-32803` chainHead_follow did not generate an operationWaitingForContinue event

The following are errors defined in the [JSON-RPC spec](https://www.jsonrpc.org/specification#error_object):
- `-32602` The provided parameter isn't one of the expected values, has different format or is missing
- `-32603` Internal server error:
  - The server was unable to generate a valid subscription ID (https://github.com/paritytech/polkadot-sdk/blob/21f1811c6600d8a7fe043592ff34dcb79284d583/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs#L198-L204)
  - The server cannot interpret the block: hardware error, ram/disk error, corrupt database, broken code logic (https://github.com/paritytech/polkadot-sdk/blob/21f1811c6600d8a7fe043592ff34dcb79284d583/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs#L306-L309)

This is done for consistency reasons, since at the moment the `chainHead_follow` is the only method that has an associated return code, although the other methods could still generate JSON-RPC errors.
This ensures interoperability as both substrate and light-client implementations will return similar codes.

cc @tomaka @jsdw @josepot @bkchr 
