### PR TITLE
storage: Clarify non-queriable storage keys

### DIFF
--- a/src/api/archive_unstable_storage.md
+++ b/src/api/archive_unstable_storage.md
@@ -119,3 +119,5 @@ It is allowed (but discouraged) for the JSON-RPC server to provide the same info
 ## Possible errors
 
 - A JSON-RPC error is generated if `type` isn't one of the allowed values (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error is generated if a `key` of the query items, or the `childTrie`
+parameter starts with the bytes of the ASCII string `:child_storage:`.

--- a/src/api/chainHead_unstable_storage.md
+++ b/src/api/chainHead_unstable_storage.md
@@ -83,3 +83,5 @@ If a `{"event": "operationWaitingForContinue"}` notification is generated, the s
 
 - A JSON-RPC error with error code `-32801` is generated if the block hash passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or the block hash has been unpinned.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
+- A JSON-RPC error with error code `-32602` is generated if a `key` of the query items, or the `childTrie`
+parameter starts with the bytes of the ASCII string `:child_storage:`.


### PR DESCRIPTION
This PR clarifies the behavior of non-querieable storage keys.

A non-queriable storage key starts with `:child_storage:` or `:child_storage:default`. 
The key could be either one of the keys passed to the `items` array of queries, or the `childTrie` parameter. 

The current behavior of substrate is no ignore those queries. However, this PR introduces a JSON-RPC error to users that the API has been wrongfully called. 

Raised from review: https://github.com/paritytech/polkadot-sdk/pull/1846#discussion_r1360512158

// cc @skunert @jsdw @tomaka @josepot 