### PR TITLE
add `withHeader` option to `chainHead_unstable_follow`

### DIFF
--- a/src/api/chainHead_unstable_follow.md
+++ b/src/api/chainHead_unstable_follow.md
@@ -3,6 +3,7 @@
 **Parameters**:
 
 - `withRuntime`: A boolean indicating whether the events should report changes to the runtime.
+- `withHeader`: A boolean indicating whether the `newBlock` and the `initialized` events should report the block's header.
 
 **Return value**: String containing an opaque value representing the operation.
 
@@ -63,11 +64,14 @@ Where `subscription` is the value returned by this function, and `result` can be
 {
     "event": "initialized",
     "finalizedBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "header": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "finalizedBlockRuntime": ...
 }
 ```
 
 The `initialized` event is always the first event to be sent back, and is only ever sent back once per subscription.
+
+`header` is present if and only if `withHeader`, the parameter to this function, is `true`. Its value is the hexadecimal-encoded SCALE-encoded header of the block.
 
 `finalizedBlockRuntime` is present if and only if `withRuntime`, the parameter to this function, is `true`.
 
@@ -80,6 +84,7 @@ The format of `finalizedBlockRuntime` is described later down this page.
     "event": "newBlock",
     "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "parentBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "header": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "newRuntime": ...
 }
 ```
@@ -87,6 +92,8 @@ The format of `finalizedBlockRuntime` is described later down this page.
 The `newBlock` indicates a new non-finalized block.
 
 `parentBlockHash` is guaranteed to be equal either to the current finalized block hash, or to a block reported in an earlier `newBlock` event.
+
+`header` is present if and only if `withHeader`, the parameter to this function, is `true`. Its value is the hexadecimal-encoded SCALE-encoded header of the block.
 
 `newRuntime` must not be present if `withRuntime`, the parameter to this function, is `false`. `newRuntime` must be `null` if the runtime hasn't changed compared to its parent.
 


### PR DESCRIPTION
I am proposing a small yet significant change in our API to introduce a `withHeader` option. This enhancement is driven by the need to simplify and optimize the way consumers interact with the `chainHead_unstable_follow` subscription, particularly in scenarios where understanding the topology of observed blocks is important. 

**Rationale:**

In our current setup, there are critical instances where a consumer needs to discern the lineage of new blocks, especially those belonging to the "best blocks" chain – blocks that, while not yet finalized, have the current "best-block" as an ancestor. The critical case involves a new block that brings a runtime upgrade. Here, the consumer is required to download the latest metadata corresponding to that runtime upgrade. This ensures that any subsequent requests targeting descendants of that block are compatible with the correct version of the runtime.

Under the existing API, achieving this demands a rather cumbersome  process. Consumers are forced to eagerly request headers for all observed blocks and subsequently hide from the final consumer blocks whose fork affiliation remains unidentified. This approach is particularly problematic when dealing with non-light-client JSON-RPC servers. It can lead to significant back-pressure issues and unnecessary bandwidth consumption due to the constant stream of [`chainHead_unstable_header`](https://paritytech.github.io/json-rpc-interface-spec/api/chainHead_unstable_header.html#chainhead_unstable_header) requests. While light-client servers may not face such challenges due to in-memory storage of headers, the inefficiency remains a concern for other server types.

**Solution:**

By integrating a `withHeader` option as proposed in this PR, we can effectively avoid these issues. This addition would streamline the process, reducing the need for redundant data requests and processing. It not only alleviates the burden on the consumer's end by simplifying the interaction model but also enhances the overall efficiency the process, mainly in non-light-client server contexts.

I believe this change, while seemingly minor, could have a substantial positive impact. I look forward to feedback and further discussion on this proposal.

cc: @tomaka 