### PR TITLE
Add `chainSpec_unstable_spec` method

### DIFF
--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -14,6 +14,8 @@ The JSON object returned by this function has the following format:
 
     "id": "...",
 
+    "protocolId": "...",
+
     "chainType": "Live" | "Local" | "Development" | { "Custom": "..." },
 
     "bootnodes": [
@@ -42,6 +44,8 @@ The JSON object returned by this function has the following format:
 - `name` is a string containing the name of the chain, identical to the result of `chainSpec_v1_chainName`.
 
 - `id` is a string containing the identifier of the chain.
+
+- `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
 
 - `chainType` is an object containing the type of the chain.  
 This information can be used by tools to display additional information to the user.  

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -14,8 +14,6 @@ The JSON object returned by this function has the following format:
 
     "id": "...",
 
-    "protocolId": "...",
-
     "chainType": "Live" | "Local" | "Development" | { "Custom": "..." },
 
     "bootnodes": [
@@ -25,6 +23,8 @@ The JSON object returned by this function has the following format:
     "genesis": {
         "stateRootHash": "0x...",
     },
+
+    // Optional fields:
 
     "telemetryEndpoints": [
         {
@@ -37,15 +37,15 @@ The JSON object returned by this function has the following format:
         "ss58Format": 0,
         "tokenDecimals": 0,
         "tokenSymbol": "...",
-    }
+    },
+
+    "protocolId": "..."
 }
 ```
 
 - `name` is a string containing the name of the chain, identical to the result of `chainSpec_v1_chainName`.
 
 - `id` is a string containing the identifier of the chain.
-
-- `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
 
 - `chainType` is an object containing the type of the chain.  
 This information can be used by tools to display additional information to the user.  
@@ -108,3 +108,5 @@ Each object has the following format:
   The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  
   The `"tokenDecimals` field is an unsigned integer indicating the number of decimals of the native token of the chain.  
   The `"tokenSymbol"` field is a string containing the symbol of the native token of the chain.
+
+- `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -44,6 +44,15 @@ The JSON object returned by this function has the following format:
     "protocolId": "...",
 
     "forkId": "...",
+
+    "checkpoint": {
+        "trustedBlocks": [
+            {
+                "blockNumber": "...",
+                "blockHash": "0x...",
+            }
+        ]
+    }
 }
 ```
 
@@ -120,3 +129,18 @@ Each object has the following format:
 - `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
 
 - `forkId` is an _optional_ string containing the fork id that identifies the chain. In the case where two chains have the same genesis, this field can be used to signal a fork on the networking level.
+
+- `checkpoint` is an _optional_ JSON object containing the checkpoint of the chain. This information could be used to synchronize the client with the head of the chain.  
+The `"trustedBlocks"` field is an array of JSON objects representing the expected hashes of blocks at given heights. This can be used to set trusted checkpoints. The client should refuse to import blocks with a different hash at the given height.
+
+    ```json
+        "trustedBlocks": [
+            {
+                "blockNumber": "...",
+                "blockHash": "0x...",
+            }
+        ]
+    ```
+
+  The `"blockNumber"` is an unsigned integer represented as string indicating the block number.  
+  The `"blockHash"` is a hexadecimal-encoded string representing the hash of the block at the given height.

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -51,7 +51,10 @@ The JSON object returned by this function has the following format:
                 "blockNumber": "...",
                 "blockHash": "0x...",
             }
-        ]
+        ],
+        "badBlocks": [
+            "0x...",
+        ],
     }
 }
 ```
@@ -142,5 +145,7 @@ The `"trustedBlocks"` field is an array of JSON objects representing the expecte
         ]
     ```
 
-  The `"blockNumber"` is an unsigned integer represented as string indicating the block number.  
-  The `"blockHash"` is a hexadecimal-encoded string representing the hash of the block at the given height.
+  - The `"blockNumber"` is an unsigned integer represented as string indicating the block number.
+  - The `"blockHash"` is a hexadecimal-encoded string representing the hash of the block at the given height.
+
+The `"badBlocks"` field is an array of hexadecimal-encoded strings representing the hashes of blocks that should be considered invalid. These hashes represent known and unwanted blocks on forks that have been pruned.

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -51,7 +51,7 @@ This fields can be one of the following values:
   - `"Development"`: A string indicating the chain is a development chain that runs mainly on one node.
   - `{ "Custom": "..." }`: A JSON object indicating the chain is a custom chain. The value of the `"Custom"` field is a string.
 
-- `bootnodes` is an array of strings containing the [p2p multiaddr](https://github.com/libp2p/specs/blob/master/addressing/README.md#the-p2p-multiaddr) of the bootnodes of the chain.  
+- `bootnodes` is an array of strings containing the [multi adresss format](https://github.com/multiformats/multiaddr) of the bootnodes of the chain.  
 For example, the `"/dns/polkadot-bootnode-0.polkadot.io/tcp/30333/p2p/12D3KooWSz8r2WyCdsfWHgPyvD8GKQdJ1UAiRmrcrs8sQB3fe2KU"` is a valid p2p multiaddr, where `12D3KooWSz8r2WyCdsfWHgPyvD8GKQdJ1UAiRmrcrs8sQB3fe2KU` represents the peer ID of the bootnode.
 To establish a connection to the chain at least one bootnode is needed.  
 The servers are encouraged to provide at least one trusted bootnode.
@@ -97,7 +97,7 @@ Each object has the following format:
     }
     ```
 
-  The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multiaddr format.  
+  The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multi address format.  
   The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server.
 
 - `properties` is an object containing the properties of the chain.  

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -30,6 +30,10 @@ The JSON object returned by this function has the following format:
 
     // Optional fields:
 
+    "codeSubstitutes": {
+        "...": "0x...",
+    },
+
     "telemetryEndpoints": [
         {
             "address": "...",
@@ -60,7 +64,7 @@ For example, the `"/dns/polkadot-bootnode-0.polkadot.io/tcp/30333/p2p/12D3KooWSz
 To establish a connection to the chain at least one bootnode is needed.  
 The servers are encouraged to provide at least one trusted bootnode.
 
-- `genesis` is an object containing the genesis storage of the chain. This field has the following formats, depending on the provided `rawGenesis` parameter.
+- `genesis` is a JSON object containing the genesis storage of the chain. This field has the following formats, depending on the provided `rawGenesis` parameter.
   - If `rawGenesis` is `true`, then the `genesis` field is a JSON object containing the raw genesis storage of the chain. The object has the following format:
 
     ```json
@@ -71,7 +75,6 @@ The servers are encouraged to provide at least one trusted bootnode.
                 ...
             },
         }
-        ...
     }
     ```
 
@@ -91,12 +94,15 @@ The servers are encouraged to provide at least one trusted bootnode.
 
     The `"stateRootHash"` contains a hexadecimal-encoded string representing the Merkle value of the genesis block.
 
-
 - `properties` is a JSON object containing a key-value map of properties of the chain.  
   The following are examples of possible properties, although implementations are free to diverge from this list:  
   The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  
   The `"tokenDecimals` field is an unsigned integer indicating the number of decimals of the native token of the chain.  
   The `"tokenSymbol"` field is a string containing the symbol of the native token of the chain.
+
+- `codeSubstitutes` is an _optional_ JSON object containing a key-value map of code substitutes of the chain. The key is an unsigned integer represented as string indicating the block number at which the code substitute is applied. The value is a hexadecimal-encoded string representing the wasm runtime code, which is normally found under `b:code:` key.  
+The given wasm runtime code is used to substitute the runtime code starting from the provided block number and until the spec-version of the chain changes.  
+A substitute should be used when runtime upgrades cannot fix an underlying issue. For example, when the runtime upgrade panics.
 
 - `telemetryEndpoints` is an _optional_ array of objects containing the telemetry endpoints of the chain.  
 Each object has the following format:

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -1,0 +1,92 @@
+# chainSpec_unstable_clientSpec
+
+**Parameters**:
+
+- `rawGenesis`: A boolean indicating whether the genesis block should be returned in raw format or not.
+
+**Return value**: A JSON object.
+
+The JSON object returned by this function has the following format:
+
+```json
+{
+    "name": "...",
+
+    "id": "...",
+
+    "chainType": "Live" | "Local" | "Development" | { "Custom": "..." },
+
+    "bootnodes": [
+        "...",
+    ],
+
+    "genesis": {
+        "stateRootHash": "0x...",
+    },
+
+    "telemetryEndpoints": [
+        {
+            "address": "...",
+            "verbosity_level": 0,
+        }
+    ],
+}
+```
+
+- `name` is a string containing the name of the chain, identical to the result of `chainSpec_v1_chainName`.
+- `id` is a string containing the identifier of the chain.
+- `chainType` is an object containing the type of the chain.  
+This information can be used by tools to display additional information to the user.  
+This fields can be one of the following values:
+  - `"Live"`: A string indicating the chain is a live chain.
+  - `"Local"`: A string indicating the chain is a local chain that runs on multiple nodes for testing purposes.
+  - `"Development"`: A string indicating the chain is a development chain that runs mainly on one node.
+  - `{ "Custom": "..." }`: A JSON object indicating the chain is a custom chain. The value of the `"Custom"` field is a string.
+- `bootnodes` is an array of strings containing the [p2p multiaddr](https://github.com/libp2p/specs/blob/master/addressing/README.md#the-p2p-multiaddr) of the bootnodes of the chain.  
+For example, the `"/dns/polkadot-bootnode-0.polkadot.io/tcp/30333/p2p/12D3KooWSz8r2WyCdsfWHgPyvD8GKQdJ1UAiRmrcrs8sQB3fe2KU"` is a valid p2p multiaddr, where `12D3KooWSz8r2WyCdsfWHgPyvD8GKQdJ1UAiRmrcrs8sQB3fe2KU` represents the peer ID of the bootnode.
+To establish a connection to the chain at least one bootnode is needed.  
+The servers are encouraged to provide at least one trusted bootnode.
+- `genesis` is an object containing the genesis storage of the chain. This field has the following formats, depending on the provided `rawGenesis` parameter.
+  - If `rawGenesis` is `true`, then the `genesis` field is a JSON object containing the raw genesis storage of the chain. The object has the following format:
+
+    ```json
+    {
+        "raw": {
+            "top": {
+                "0x..": "0x..",
+                ...
+            },
+        }
+        ...
+    }
+    ```
+
+    The `"top"` field contains a map of keys to values for the top-level storage entries of the genesis.  
+    Both the keys and the values are hexadecimal-encoded strings.  
+    The provided keys are guaranteed to be unique and to not be a default storage child key. A default storage child key is a key that is prefixed with `b":child_storage:default:"`.  
+    For example, the wasm code of the runtime is stored under the key `b":code"`.
+
+  - If `rawGenesis` is `false`, then the `genesis` field is a JSON object containing the Merkle value of the genesis block.
+  The object has the following format:
+
+    ```json
+    {
+        "stateRootHash": "0x...",
+    }
+    ```
+
+    The `"stateRootHash"` contains a hexadecimal-encoded string representing the Merkle value of the genesis block.
+
+- `telemetryEndpoints` is an array of objects containing the telemetry endpoints of the chain.  
+Each object has the following format:
+
+    ```json
+    {
+        "address": "...",
+        "verbosity_level": 0,
+    }
+    ```
+
+  The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multiaddr format.  
+  The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server.
+

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -87,7 +87,7 @@ The servers are encouraged to provide at least one trusted bootnode.
 
     The `"stateRootHash"` contains a hexadecimal-encoded string representing the Merkle value of the genesis block.
 
-- `telemetryEndpoints` is an array of objects containing the telemetry endpoints of the chain.  
+- `telemetryEndpoints` is an _optional_ array of objects containing the telemetry endpoints of the chain.  
 Each object has the following format:
 
     ```json
@@ -98,7 +98,7 @@ Each object has the following format:
     ```
 
   The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multi address format.  
-  The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server.
+  The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server. The verbosity ranges from 0 to 9, where 0 is the least verbose and 9 is the most verbose.
 
 - `properties` is an object containing the properties of the chain.  
   The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -46,6 +46,11 @@ The JSON object returned by this function has the following format:
         "forkId": "...",
     },
 
+    "parachain": {
+        "id": 0,
+        "relayChain": "..."
+    },
+
     "checkpoint": {
         "trustedBlocks": [
             {
@@ -141,6 +146,18 @@ Each object has the following format:
 
   - `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
   - `forkId` is an _optional_ string containing the fork id that identifies the chain. In the case where two chains have the same genesis, this field can be used to signal a fork on the networking level.
+
+- `parachain` is an _optional_ JSON object containing the parachain information. This fields is present only if the client spec describes a parachain. The object has the following format:
+
+    ```json
+    {
+        "id": 0,
+        "relayChain": "..."
+    }
+    ```
+
+  - `id` is an unsigned integer indicating the id of the parachain.
+  - `relayChain` is a string containing the identifier of the relay chain.
 
 - `checkpoint` is an _optional_ JSON object containing the checkpoint of the chain. This information could be used to synchronize the client with the head of the chain.  
 The `"trustedBlocks"` field is an array of JSON objects representing the expected hashes of blocks at given heights. This can be used to set trusted checkpoints. The client should refuse to import blocks with a different hash at the given height.

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -39,7 +39,9 @@ The JSON object returned by this function has the following format:
         "tokenSymbol": "...",
     },
 
-    "protocolId": "..."
+    "protocolId": "...",
+
+    "forkId": "...",
 }
 ```
 
@@ -104,9 +106,11 @@ Each object has the following format:
   The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multi address format.  
   The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server. The verbosity ranges from 0 to 9, where 0 is the least verbose and 9 is the most verbose.
 
-- `properties` is an object containing the properties of the chain.  
+- `properties` is an _optional_ object containing the properties of the chain.  
   The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  
   The `"tokenDecimals` field is an unsigned integer indicating the number of decimals of the native token of the chain.  
   The `"tokenSymbol"` field is a string containing the symbol of the native token of the chain.
 
 - `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
+
+- `forkId` is an _optional_ string containing the fork id that identifies the chain. In the case where two chains have the same genesis, this field can be used to signal a fork on the networking level.

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -34,7 +34,9 @@ The JSON object returned by this function has the following format:
 ```
 
 - `name` is a string containing the name of the chain, identical to the result of `chainSpec_v1_chainName`.
+
 - `id` is a string containing the identifier of the chain.
+
 - `chainType` is an object containing the type of the chain.  
 This information can be used by tools to display additional information to the user.  
 This fields can be one of the following values:
@@ -42,10 +44,12 @@ This fields can be one of the following values:
   - `"Local"`: A string indicating the chain is a local chain that runs on multiple nodes for testing purposes.
   - `"Development"`: A string indicating the chain is a development chain that runs mainly on one node.
   - `{ "Custom": "..." }`: A JSON object indicating the chain is a custom chain. The value of the `"Custom"` field is a string.
+
 - `bootnodes` is an array of strings containing the [p2p multiaddr](https://github.com/libp2p/specs/blob/master/addressing/README.md#the-p2p-multiaddr) of the bootnodes of the chain.  
 For example, the `"/dns/polkadot-bootnode-0.polkadot.io/tcp/30333/p2p/12D3KooWSz8r2WyCdsfWHgPyvD8GKQdJ1UAiRmrcrs8sQB3fe2KU"` is a valid p2p multiaddr, where `12D3KooWSz8r2WyCdsfWHgPyvD8GKQdJ1UAiRmrcrs8sQB3fe2KU` represents the peer ID of the bootnode.
 To establish a connection to the chain at least one bootnode is needed.  
 The servers are encouraged to provide at least one trusted bootnode.
+
 - `genesis` is an object containing the genesis storage of the chain. This field has the following formats, depending on the provided `rawGenesis` parameter.
   - If `rawGenesis` is `true`, then the `genesis` field is a JSON object containing the raw genesis storage of the chain. The object has the following format:
 
@@ -89,4 +93,3 @@ Each object has the following format:
 
   The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multiaddr format.  
   The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server.
-

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -1,4 +1,4 @@
-# chainSpec_unstable_clientSpec
+# chainSpec_unstable_spec
 
 **Parameters**:
 

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -41,9 +41,10 @@ The JSON object returned by this function has the following format:
         }
     ],
 
-    "protocolId": "...",
-
-    "forkId": "...",
+    "networkProperties": {
+        "protocolId": "...",
+        "forkId": "...",
+    },
 
     "checkpoint": {
         "trustedBlocks": [
@@ -126,12 +127,20 @@ Each object has the following format:
     }
     ```
 
-  The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multi address format.  
-  The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server. The verbosity ranges from 0 to 9, where 0 is the least verbose and 9 is the most verbose.
+  - `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multi address format.  
+  - `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server. The verbosity ranges from 0 to 9, where 0 is the least verbose and 9 is the most verbose.
 
-- `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
+- `networkProperties` is an _optional_ JSON object containing the network properties of the chain. The object has the following format:
 
-- `forkId` is an _optional_ string containing the fork id that identifies the chain. In the case where two chains have the same genesis, this field can be used to signal a fork on the networking level.
+    ```json
+    {
+        "protocolId": "...",
+        "forkId": "...",
+    }
+    ```
+
+  - `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
+  - `forkId` is an _optional_ string containing the fork id that identifies the chain. In the case where two chains have the same genesis, this field can be used to signal a fork on the networking level.
 
 - `checkpoint` is an _optional_ JSON object containing the checkpoint of the chain. This information could be used to synchronize the client with the head of the chain.  
 The `"trustedBlocks"` field is an array of JSON objects representing the expected hashes of blocks at given heights. This can be used to set trusted checkpoints. The client should refuse to import blocks with a different hash at the given height.
@@ -145,7 +154,7 @@ The `"trustedBlocks"` field is an array of JSON objects representing the expecte
         ]
     ```
 
-  - The `"blockNumber"` is an unsigned integer represented as string indicating the block number.
-  - The `"blockHash"` is a hexadecimal-encoded string representing the hash of the block at the given height.
+  - `"blockNumber"` is an unsigned integer represented as string indicating the block number.
+  - `"blockHash"` is a hexadecimal-encoded string representing the hash of the block at the given height.
 
-The `"badBlocks"` field is an array of hexadecimal-encoded strings representing the hashes of blocks that should be considered invalid. These hashes represent known and unwanted blocks on forks that have been pruned.
+  The `"badBlocks"` field is an array of hexadecimal-encoded strings representing the hashes of blocks that should be considered invalid. These hashes represent known and unwanted blocks on forks that have been pruned.

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -24,6 +24,10 @@ The JSON object returned by this function has the following format:
         "stateRootHash": "0x...",
     },
 
+    "properties": {
+        ...
+    },
+
     // Optional fields:
 
     "telemetryEndpoints": [
@@ -32,12 +36,6 @@ The JSON object returned by this function has the following format:
             "verbosity_level": 0,
         }
     ],
-
-    "properties": {
-        "ss58Format": 0,
-        "tokenDecimals": 0,
-        "tokenSymbol": "...",
-    },
 
     "protocolId": "...",
 
@@ -93,6 +91,13 @@ The servers are encouraged to provide at least one trusted bootnode.
 
     The `"stateRootHash"` contains a hexadecimal-encoded string representing the Merkle value of the genesis block.
 
+
+- `properties` is a JSON object containing a key-value map of properties of the chain.  
+  The following are examples of possible properties, although implementations are free to diverge from this list:  
+  The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  
+  The `"tokenDecimals` field is an unsigned integer indicating the number of decimals of the native token of the chain.  
+  The `"tokenSymbol"` field is a string containing the symbol of the native token of the chain.
+
 - `telemetryEndpoints` is an _optional_ array of objects containing the telemetry endpoints of the chain.  
 Each object has the following format:
 
@@ -105,11 +110,6 @@ Each object has the following format:
 
   The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multi address format.  
   The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server. The verbosity ranges from 0 to 9, where 0 is the least verbose and 9 is the most verbose.
-
-- `properties` is an _optional_ object containing the properties of the chain.  
-  The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  
-  The `"tokenDecimals` field is an unsigned integer indicating the number of decimals of the native token of the chain.  
-  The `"tokenSymbol"` field is a string containing the symbol of the native token of the chain.
 
 - `protocolId` is an _optional_ string containing the network protocol id that identifies the chain.
 

--- a/src/api/chainSpec_unstable_spec.md
+++ b/src/api/chainSpec_unstable_spec.md
@@ -30,6 +30,12 @@ The JSON object returned by this function has the following format:
             "verbosity_level": 0,
         }
     ],
+
+    "properties": {
+        "ss58Format": 0,
+        "tokenDecimals": 0,
+        "tokenSymbol": "...",
+    }
 }
 ```
 
@@ -93,3 +99,8 @@ Each object has the following format:
 
   The `"address"` is a string containing the address of the telemetry server. The address can be specified in the URL format, or in the multiaddr format.  
   The `"verbosity_level"` is an unsigned integer indicating the verbosity level of the telemetry server.
+
+- `properties` is an object containing the properties of the chain.  
+  The `"ss58Format"` field is an unsigned integer indicating the designated SS58 prefix of the addresses of the chain. For more details see [Polkadot Accounts In-Depth](https://wiki.polkadot.network/docs/learn-account-advanced).  
+  The `"tokenDecimals` field is an unsigned integer indicating the number of decimals of the native token of the chain.  
+  The `"tokenSymbol"` field is a string containing the symbol of the native token of the chain.


### PR DESCRIPTION
This PR adds the `chainSpec_unstable_spec` method to fetch the chainSpec from a running node.

Substrate nodes expose currently `sync_state_genSyncSpec`. The new method unifies the format of substrate chain-spec needed for the light-clients to sync to the head of the chain.

There are several differences from the traditional chain-spec:
- the `Genesis` entry contains either a `Raw` entry or a `stateRootHash` entry
  - the `stateRootHash` represents the merkle value of the genesis. This is an optimisation used by smoldot to store smaller chainSpec files, and to allow light-clients to sync up faster (since a raw entry must be first converted to a `stateRootHash` entry).
- `protocolID` and `forkId` are placed under a common `networkProperties` object
- `para_id` and `relay_chain` are placed under a common `parachain` object; while using camelCase naming
- `telemetryEndpoints` contains objects instead of tuples to explicitly describe the `address` of the telemetry server and the `verbosity_level`
- a new `checkpoint` object is added
  - the `forkedBlocks` entry is renamed to `trustedBlocks` and moved under this object
    - `forkedBlocks` are now identified by a block number and block hash
  - the `badBlocks` are moved under this object
  

The `checkpoint` object could then be extended to include the syncState needed by lightclients: https://github.com/paritytech/substrate/issues/11184

Block numbers are represented as string unsigned integers, similar to the current chainSpec. I believe this may be an artifact of javaScript users.

Would love to get your thoughts on this 🙏 
// cc @jsdw @tomaka @bkchr @skunert 
  