### PR TITLE
Return an error if sudo_network_unstable_unwatch is passed a wrong ID

### DIFF
--- a/src/api/sudo_network_unstable_unwatch.md
+++ b/src/api/sudo_network_unstable_unwatch.md
@@ -7,3 +7,7 @@
 **Return value**: *null*
 
 JSON-RPC client implementations must be aware that, due to the asynchronous nature of JSON-RPC client <-> server communication, they might still receive notifications concerning this subscription, for example because these notifications were already in the process of being sent back by the JSON-RPC server.
+
+## Possible errors
+
+A JSON-RPC error is generated if the `subscription` doesn't correspond to any active subscription.


### PR DESCRIPTION
It is right now not mentioned what happens in that situation