### PR TITLE
chainHead/unpin: Return error on duplicate hashes

### DIFF
--- a/src/api/chainHead_unstable_unpin.md
+++ b/src/api/chainHead_unstable_unpin.md
@@ -3,7 +3,7 @@
 **Parameters**:
 
 - `followSubscription`: An opaque string that was returned by `chainHead_unstable_follow`.
-- `hashOrHashes`: String or array of strings containing the hexadecimal-encoded hash of the header of the block to unpin.
+- `hashOrHashes`: String or array of unique strings containing the hexadecimal-encoded hash of the header of the block to unpin.
 
 **Return value**: *null*
 
@@ -18,5 +18,6 @@ If this function returns an error, then no block has been unpinned. An JSON-RPC 
 ## Possible errors
 
 - A JSON-RPC error with error code `-32801` is generated if the `followSubscription` is valid but at least one of the block hashes passed as parameter doesn't correspond to any block that has been reported by `chainHead_unstable_follow`, or at least one of the block hashes has been unpinned.
+- A JSON-RPC error with error code `-32804` is generated if the `hashOrHashes` parameter is an array and at least one of the block hashes is duplicated.
 - A JSON-RPC error with error code `-32602` is generated if one of the parameters doesn't correspond to the expected type (similarly to a missing parameter or an invalid parameter type).
 - No error is generated if the `followSubscription` is invalid or stale. The call is simply ignored.


### PR DESCRIPTION
This PR clarifies the behavior of the server when the `chainHead_unpin` receives duplicate hashes.

When duplicate hashes are received as parameters, the server returns `-32804`.
Likewise, the server could return the `-32602` for invalid parameters. However, I thought a dedicated error would provide clear details to the user wrt what needs to be changed. This felt appropriate since we also have a dedicated error for `withRuntime` flag:
> `-32802` is generated if the `followSubscription` corresponds to a follow where `withRuntime` was `false`.


cc @paritytech/subxt-team 
cc: https://github.com/paritytech/polkadot-sdk/pull/3313#discussion_r1488492795

Closes: https://github.com/paritytech/json-rpc-interface-spec/issues/133