### PR TITLE
txWatch: Remove the txWatch limits

### DIFF
--- a/src/api/transactionWatch_unstable_submitAndWatch.md
+++ b/src/api/transactionWatch_unstable_submitAndWatch.md
@@ -10,8 +10,6 @@ The string returned by this function is opaque and its meaning can't be interpre
 
 Once this function has been called, the server will try to propagate this transaction over the peer-to-peer network and/or include it onto the chain even if `transactionWatch_unstable_unwatch` is called or that the JSON-RPC client disconnects. In other words, it is not possible to cancel submitting a transaction.
 
-The JSON-RPC server must accept at least 4 `transactionWatch_unstable_submitAndWatch` subscriptions per JSON-RPC client.
-Trying to open more might lead to a JSON-RPC error when calling `transactionWatch_unstable_submitAndWatch`.
 
 ## Notifications format
 
@@ -168,5 +166,4 @@ JSON-RPC servers are allowed to skip sending events as long as it properly keeps
 
 ## Possible errors
 
-- A JSON-RPC error with error code `-32800` can be generated if the JSON-RPC client has already opened 4 or more `transactionWatch_unstable_submitAndWatch` subscriptions.
 - A JSON-RPC error with error code `-32602` is generated if the `transaction` parameter is not a valid hex string. Note that no error is produced if the bytes of the `transaction`, once decoded, are invalid. Instead, an `invalid` notification will be generated.


### PR DESCRIPTION
This PR is a followup of the proposal from: https://github.com/paritytech/json-rpc-interface-spec/pull/150#pullrequestreview-1988787293

In this PR, the concept of limits is removed from the `transactionWatch`, as noted in: https://github.com/paritytech/json-rpc-interface-spec/pull/150.
- Servers can still return `Transaction::Dropped` if the node cannot keep up with the number of transactions (as per spec), however servers are not required to support a minimum of 4 subscriptions per client

cc @paritytech/subxt-team @tomaka 