### PR TITLE
Add `archive_unstable_stopStorage`

### DIFF
--- a/src/api/archive_unstable_stopStorage.md
+++ b/src/api/archive_unstable_stopStorage.md
@@ -1,0 +1,11 @@
+# archive_unstable_stopStorage
+
+**Parameters**:
+
+- An opaque string that was returned by `archive_unstable_storage`.
+
+**Return value**: *null*
+
+Stops a subscription started with `archive_unstable_storage`. Has no effect if the opaque string is invalid or refers to a subscription that has already emitted a `{"event": "storageDone"}` event.
+
+JSON-RPC client implementations must be aware that, due to the asynchronous nature of JSON-RPC client <-> server communication, they might still receive chain updates notifications, for example because these notifications were already in the process of being sent back by the JSON-RPC server.


### PR DESCRIPTION
We already have `archive_unstable_stopStorageDiff` to stop `archive_unstable_storageDiff` subscriptions. For consistency, we add  `archive_unstable_stopStorage` to stop `archive_unstable_storage` subscriptions.

Side note: `archive_unstable_stopStorage` is already used in the Substrate impl so nothing to do there to be compliant with this.