### PR TITLE
Add `bitswap_v1_get` method

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,6 +18,8 @@
     - [archive_v1_stopStorageDiff](api/archive_v1_stopStorageDiff.md)
     - [archive_v1_storage](api/archive_v1_storage.md)
     - [archive_v1_storageDiff](api/archive_v1_storageDiff.md)
+  - [bitswap](api/bitswap.md)
+    - [bitswap_v1_get](api/bitswap_v1_get.md)
   - [chainHead](api/chainHead.md)
     - [chainHead_v1_body](api/chainHead_v1_body.md)
     - [chainHead_v1_call](api/chainHead_v1_call.md)

--- a/src/api/bitswap.md
+++ b/src/api/bitswap.md
@@ -6,3 +6,6 @@ normally downloaded using Bitswap protocol.
 If these methods are called on a full node, the data is returned from a local database. If the
 methods are called on a light client, it tries to download the data via Bitswap protocol from full
 nodes.
+
+The full node may also implement downloading the data from other full nodes via Bitswap protocol
+if it doesn't have the data locally (e.g., due to the block pruning settings).

--- a/src/api/bitswap.md
+++ b/src/api/bitswap.md
@@ -1,0 +1,8 @@
+# Introduction
+
+The functions with `bitswap` prefix allow fetching data chunks from the storage given their CID,
+normally downloaded using Bitswap protocol.
+
+If these methods are called on a full node, the data is returned from a local database. If the
+methods are called on a light client, it tries to download the data via Bitswap protocol from full
+nodes.

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -32,8 +32,8 @@ For error category `Fail` retrying doesn't make sense unless the data has been a
 after the failure.
 
 Error category `FailRetry` can be retried immediately. For example, request timeout falls into this
-category. Even though you can retry immediately, the implementations are encouraged to rate-limit
-the retry attempts.
+category. Even though the client can retry immediately, the implementations are encouraged to
+rate-limit the retry attempts and limit the total number of retries.
 
 Error category `FailRetryBackoff` can be retried after a delay. For example, such error can be
 generated if no peers are currently connected to the light client. Recommended delay before retrying

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -41,11 +41,11 @@ programmatically.
 
 ### Detailed error information
 
-| Field          | Description                               | Example value                    |
-| -------------- | ----------------------------------------- | -------------------------------- |
-| `message`      | Human-readable error description          | `Request timeout.`               |
-| `data.variant` | Error variant for structured logging      | `Timeout`, `NoPeers`, `NotFound` |
-| `data.details` | Present only for `InvalidParams` category | `Unsupported multibase codec`    |
+| Field          | Description                               | Example value                         |
+| -------------- | ----------------------------------------- | ------------------------------------- |
+| `message`      | Human-readable error description          | `Request timeout.`                    |
+| `data.variant` | Error variant for structured logging      | `Timeout`, `NoPeers`, `NotFound`, ... |
+| `data.details` | Present only for `InvalidParams` category | `Unsupported multibase codec`         |
 
 ### Example JSON-RPC `error` field
 

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -19,10 +19,13 @@ indicates a possible retry strategy.
 
 | Code   | Category            | Meaning                                                 |
 | ------ | ------------------- | ------------------------------------------------------- |
-| -32602 | `InvalidParams`     | Invalid/unsupported CID was passed. Must not retry      |
+| -32602 | `InvalidParams`     | Invalid/unsupported CID was passed                      |
 | -32810 | `Fail`              | Permanent failure for this request, e.g. data not found |
 | -32811 | `FailRetry`         | Transient failure, can retry immediately                |
 | -32812 | `FailRetryBackoff`  | Transient failure, can retry with a delay               |
+
+`InvalidParams` is a standard JSON-RPC error indicating invalid data passed to the method.
+The client must not call the method with the same argument again.
 
 For error category `Fail` retrying doesn't make sense unless the data has been added to the network
 after the failure.
@@ -41,11 +44,10 @@ programmatically.
 
 ### Detailed error information
 
-| Field          | Description                               | Example value                         |
-| -------------- | ----------------------------------------- | ------------------------------------- |
-| `message`      | Human-readable error description          | `Request timeout.`                    |
-| `data.variant` | Error variant for structured logging      | `Timeout`, `NoPeers`, `NotFound`, ... |
-| `data.details` | Present only for `InvalidParams` category | `Unsupported multibase codec`         |
+| Field          | Description                          | Example value                         |
+| -------------- | ------------------------------------ | ------------------------------------- |
+| `message`      | Human-readable error description     | `Request timeout.`                    |
+| `data.variant` | Error variant for structured logging | `Timeout`, `NoPeers`, `NotFound`, ... |
 
 ### Example JSON-RPC `error` field
 

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -8,9 +8,10 @@
   Example: `bafk2bzacec5lindttapqst35gv4767ig2vxmcaeherlaubtqhufg4tqqmeen4`.
 
 
-**Return value**: String containing the requested data chunk, hexadecimal-encoded. Always starts with
-`0x...`. Because Bitswap chunks are limited by 2 MiB at the transport layer, the maximum returned
-string size is 4 MiB + 2 B.
+**Return value**: String containing the requested data chunk, hexadecimal-encoded. Always starts
+with `0x...`.  
+Because Bitswap chunks are limited by 2 MiB at the transport layer, the maximum returned string size
+is 4 MiB + 2 B.
 
 **Errors**: If the data chunk retrieval fails, JSON-RPC call fails. The error code
 indicates a possible retry strategy.

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -1,0 +1,56 @@
+# bitswap_v1_get
+
+**Parameters**:
+
+- `cid`: CID of the data chunk requested serialized in a [string format](https://github.com/multiformats/cid/blob/edb1c5294ad2d8257812d7ded4941c3e0fafccf3/README.md#variant---stringified-form).
+  Only CIDv1 version in `base32` multibase encoding (string starting from `b...`) is supported.
+  Only `sha2-256` and `blake2b-256` hash functions are supported.
+  Example: `bafk2bzacec5lindttapqst35gv4767ig2vxmcaeherlaubtqhufg4tqqmeen4`.
+
+
+**Return value**: String containing the requested data chunk, hexadecimal-encoded. Always starts with
+`0x...`.
+
+**Errors**: If the data chunk retrieval fails, JSON-RPC call fails. The error code
+indicates a possible retry strategy.
+
+## Error categories
+
+| Code   | Category            | Meaning                                                 |
+| ------ | ------------------- | ------------------------------------------------------- |
+| -32602 | `InvalidParams`     | Invalid/unsupported CID was passed. Must not retry      |
+| -32810 | `Fail`              | Permanent failure for this request, e.g. data not found |
+| -32811 | `FailRetry`         | Transient failure, can retry immediately                |
+| -32812 | `FailRetryBackoff`  | Transient failure, can retry with a delay               |
+
+For error category `Fail` retrying doesn't make sense unless the data has been added to the network
+after the failure.
+
+Error category `FailRetry` can be retried immediately. For example, request timeout falls into this
+category. Even though you can retry immediately, the implementations are encouraged to rate-limit
+the retry attempts.
+
+Error category `FailRetryBackoff` can be retried after a delay. For example, such error can be
+generated if no peers are currently connected to the light client. Recommended delay before retrying
+is 1-5 seconds.
+
+Detailed error information for debugging/logging purposes can be obtained from the JSON error
+response. This information is implementation-specific and subject to change, so must not be used
+programmatically.
+
+### Detailed error information
+
+| Field          | Description                               | Example value                    |
+| -------------- | ----------------------------------------- | -------------------------------- |
+| `message`      | Human-readable error description          | `Request timeout.`               |
+| `data.variant` | Error variant for structured logging      | `Timeout`, `NoPeers`, `NotFound` |
+| `data.details` | Present only for `InvalidParams` category | `Unsupported multibase codec`    |
+
+### Example JSON-RPC `error` field
+
+```json
+{"code": -32812, "message": "No Bitswap peers connected", "data": {"variant": "NoPeers"}}
+```
+
+Please note again that this information is provided for debugging purposes only, not stable, and
+must not be relied upon in business logic.

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -9,7 +9,8 @@
 
 
 **Return value**: String containing the requested data chunk, hexadecimal-encoded. Always starts with
-`0x...`.
+`0x...`. Because Bitswap chunks are limited by 2 MiB at the transport layer, the maximum returned
+string size is 4 MiB + 2 B.
 
 **Errors**: If the data chunk retrieval fails, JSON-RPC call fails. The error code
 indicates a possible retry strategy.
@@ -34,7 +35,7 @@ Error category `FailRetryBackoff` can be retried after a delay. For example, suc
 generated if no peers are currently connected to the light client. Recommended delay before retrying
 is 1-5 seconds.
 
-Detailed error information for debugging/logging purposes can be obtained from the JSON error
+Detailed error information for debugging/logging purposes can be obtained from the JSON-RPC error
 response. This information is implementation-specific and subject to change, so must not be used
 programmatically.
 

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -52,5 +52,6 @@ programmatically.
 {"code": -32812, "message": "No Bitswap peers connected", "data": {"variant": "NoPeers"}}
 ```
 
-Please note again that this information is provided for debugging purposes only, not stable, and
-must not be relied upon in business logic.
+Please note again that only the `code` and corresponding error retry categories in the table above
+are stable. Everything else is provided for debugging purposes only, subject to change, and must not
+be relied upon in business logic.

--- a/src/api/bitswap_v1_get.md
+++ b/src/api/bitswap_v1_get.md
@@ -2,9 +2,9 @@
 
 **Parameters**:
 
-- `cid`: CID of the data chunk requested serialized in a [string format](https://github.com/multiformats/cid/blob/edb1c5294ad2d8257812d7ded4941c3e0fafccf3/README.md#variant---stringified-form).
-  Only CIDv1 version in `base32` multibase encoding (string starting from `b...`) is supported.
-  Only `sha2-256` and `blake2b-256` hash functions are supported.
+- `cid`: CID of the data chunk requested serialized in a [string format](https://github.com/multiformats/cid/blob/edb1c5294ad2d8257812d7ded4941c3e0fafccf3/README.md#variant---stringified-form).  
+  Only CIDv1 version in `base32` multibase encoding (string starting from `b...`) is supported.  
+  Only `sha2-256` and `blake2b-256` hash functions are supported.  
   Example: `bafk2bzacec5lindttapqst35gv4767ig2vxmcaeherlaubtqhufg4tqqmeen4`.
 
 


### PR DESCRIPTION
This PR standardizes `bitswap_v1_get` RPC used to download data from Polkadot Bulletin Chain. Calling this method is equivalent to downloading the data from a full node via Bitswap protocol. Both light & full nodes must provide this endpoint.

## Follow-ups

`bitswap_v1_stream` method for requesting streaming of multiple Bitswap chunks (multiple CIDs) will be introduced in a separate PR.

CC @ERussel